### PR TITLE
Add vendor version for libgui

### DIFF
--- a/libs/gui/Android.bp
+++ b/libs/gui/Android.bp
@@ -30,12 +30,9 @@ cc_library_headers {
     min_sdk_version: "29",
 }
 
-cc_library_shared {
-    name: "libgui",
-    vendor_available: false,
-    vndk: {
-        enabled: true,
-    },
+cc_defaults {
+    name: "libgui_defaults",
+
     double_loadable: true,
 
     defaults: ["libgui_bufferqueue-defaults"],
@@ -262,6 +259,22 @@ cc_library_static {
         "mock/GraphicBufferConsumer.cpp",
         "mock/GraphicBufferProducer.cpp",
     ],
+}
+
+cc_library_shared {
+    name: "libgui",
+    vendor_available: false,
+    vndk: {
+        enabled: true,
+    },
+    double_loadable: true,
+    defaults: ["libgui_defaults"]
+}
+
+cc_library_shared {
+    name: "libgui_vendor",
+    vendor: true,
+    defaults: ["libgui_defaults"]
 }
 
 subdirs = ["tests"]


### PR DESCRIPTION
libstagefright_omx library need to be extended to vendor which
is depenednet on libgui which is a vndk_private lib.
Creating vendor version so that libstagefright_omx_ext can link
to libgui_vendor.

 Conflicts:
	libs/gui/Android.bp

CRs-Fixed: 2258968
Change-Id: I777eebffc405c8bb74aab270e9f272c806501458
Signed-off-by: Volodymyr Zhdanov <wight554@gmail.com>