### PR TITLE
Don't quantize max range with a resolution of 0

### DIFF
--- a/services/sensorservice/SensorDevice.cpp
+++ b/services/sensorservice/SensorDevice.cpp
@@ -153,12 +153,18 @@ void SensorDevice::initializeSensorList() {
                                     SensorDeviceUtils::defaultResolutionForType(sensor.type);
                         }
 
-                        double promotedResolution = sensor.resolution;
-                        double promotedMaxRange = sensor.maxRange;
-                        if (fmod(promotedMaxRange, promotedResolution) != 0) {
-                            ALOGW("%s's max range %f is not a multiple of the resolution %f",
-                                    sensor.name, sensor.maxRange, sensor.resolution);
-                            SensorDeviceUtils::quantizeValue(&sensor.maxRange, promotedResolution);
+                        // Some sensors don't have a default resolution and will be left at 0.
+                        // Don't crash in this case since CTS will verify that devices don't go to
+                        // production with a resolution of 0.
+                        if (sensor.resolution != 0) {
+                            double promotedResolution = sensor.resolution;
+                            double promotedMaxRange = sensor.maxRange;
+                            if (fmod(promotedMaxRange, promotedResolution) != 0) {
+                                ALOGW("%s's max range %f is not a multiple of the resolution %f",
+                                        sensor.name, sensor.maxRange, sensor.resolution);
+                                SensorDeviceUtils::quantizeValue(
+                                        &sensor.maxRange, promotedResolution);
+                            }
                         }
                     }
 


### PR DESCRIPTION
Sensors without a default resolution can be left with a resolution of 0
during initialization. Then, when the framework attempted to requantize
the max range using the resolution value, it would perform a
divide-by-zero operation. Encapsulate this logic with a check of the
resolution value to ensure this case doesn't occur.

Bug: 160862405
Test: Run on device and verify no crashes occur.
Merged-In: I6ab02072a11078f05f65b61310d5637743e258ff
Change-Id: I6ab02072a11078f05f65b61310d5637743e258ff
(cherry picked from commit ec5b4b1eebd9919ec54ff2d03d17fbf387012d1d)