### PR TITLE
SurfaceFlinger: Allow forcing HWC brightness support

### DIFF
--- a/services/surfaceflinger/SurfaceFlinger.cpp
+++ b/services/surfaceflinger/SurfaceFlinger.cpp
@@ -430,6 +430,9 @@ SurfaceFlinger::SurfaceFlinger(Factory& factory) : SurfaceFlinger(factory, SkipI
     property_get("debug.sf.treat_170m_as_sRGB", value, "0");
     mTreat170mAsSrgb = atoi(value);
 
+    property_get("ro.sf.force_hwc_brightness", value, "0");
+    mForceHwcBrightness = atoi(value);
+
     // We should be reading 'persist.sys.sf.color_saturation' here
     // but since /data may be encrypted, we need to wait until after vold
     // comes online to attempt to read the property. The property is
@@ -1686,7 +1689,8 @@ status_t SurfaceFlinger::getDisplayBrightnessSupport(const sp<IBinder>& displayT
     if (!displayId) {
         return NAME_NOT_FOUND;
     }
-    *outSupport = getHwComposer().hasDisplayCapability(*displayId, DisplayCapability::BRIGHTNESS);
+    *outSupport = mForceHwcBrightness ? true :
+        getHwComposer().hasDisplayCapability(*displayId, DisplayCapability::BRIGHTNESS);
     return NO_ERROR;
 }
 

--- a/services/surfaceflinger/SurfaceFlinger.h
+++ b/services/surfaceflinger/SurfaceFlinger.h
@@ -1372,6 +1372,7 @@ private:
     bool mSetActiveModePending = false;
 
     bool mLumaSampling = true;
+    bool mForceHwcBrightness = false;
     sp<RegionSamplingThread> mRegionSamplingThread;
     sp<FpsReporter> mFpsReporter;
     sp<TunnelModeEnabledReporter> mTunnelModeEnabledReporter;


### PR DESCRIPTION
Some vendors purposely disable brightness capability even though the HWC completely supports it, in order to leverage their custom brightness implementations. One such example of this is in stock HWC of some
xiaomi devices.

Since light HAL offers lesser granual control than HWC (since its in gamma space and not float), and
since it would be rather difficult to patch the blob to return the right capabilities, allow forcing the usage of HWC brightness functions via a prop:

ro.sf.force_hwc_brightness=1 (default 0).

Change-Id: I7d2fef03afbbb936572c717f769f30c9e49213e0
Signed-off-by: Adithya R <gh0strider.2k18.reborn@gmail.com>